### PR TITLE
Fix thousands hidden exception leads to Map freezes

### DIFF
--- a/src/org/openstreetmap/gui/jmapviewer/OsmMercator.java
+++ b/src/org/openstreetmap/gui/jmapviewer/OsmMercator.java
@@ -72,8 +72,11 @@ public class OsmMercator {
         return -1 * getMaxPixels(aZoomlevel) / 2;
     }
 
+    private static Boolean isRetina = null;
     public static boolean isRetina() {
-        boolean isRetina = false;
+        if (isRetina!=null)
+        	return isRetina;
+        isRetina = false;
         final GraphicsEnvironment env = GraphicsEnvironment.getLocalGraphicsEnvironment();
         final GraphicsDevice device = env.getDefaultScreenDevice();
         try {


### PR DESCRIPTION
On my system (Windows10 with JVM1.8) every call to isRetina() function leads to Exception, which is very expensive